### PR TITLE
Improve error monitoring in Websites API calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hat-server",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "Head App Template - server",
     "license": "MIT",
     "repository": {},

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     },
     "private": false,
     "dependencies": {
-        "@ringpublishing/graphql-api-client": "^4.2.0",
-        "@ringpublishing/graphql-api-client-got": "^2.3.0",
+        "@ringpublishing/graphql-api-client-got": "^2.3.1",
         "@types/http-server": "^0.12.1",
         "@types/node": "*"
     },

--- a/src/server/BootServer.ts
+++ b/src/server/BootServer.ts
@@ -1,7 +1,6 @@
 import {parse, UrlWithParsedQuery} from 'url';
 import * as http from "http";
-import {gql} from '@ringpublishing/graphql-api-client';
-import {WebsitesApiClient} from "@ringpublishing/graphql-api-client-got";
+import {WebsitesApiClient, gql} from "@ringpublishing/graphql-api-client-got";
 import {DocumentNode} from 'graphql/language/ast';
 import {
     BootServerConfig, CacheService,

--- a/src/server/BootServer.ts
+++ b/src/server/BootServer.ts
@@ -365,16 +365,25 @@ export class BootServer {
             if (newResponse.errors || newResponse.error) {
                 console.error('Hat-server: Websites Api error:', query.loc?.source.body, newResponse.errors, newResponse.error);
                 if (global['monitoringProvider'] && global['monitoringProvider'].counter) {
-                    global['monitoringProvider'].counter('info.HatServer_callToWebsitesApi.apiCallError');
+                    global['monitoringProvider'].counter('error.HatServer_callToWebsitesApi.apiCallError');
                 }
-                return newResponse.data ? newResponse : null;
+
+                if (newResponse.data) {
+                    return newResponse;
+                }
+
+                if (global['monitoringProvider'] && global['monitoringProvider'].counter) {
+                    global['monitoringProvider'].counter('error.HatServer_callToWebsitesApi.apiCallNoDataInResponse');
+                }
+
+                return null;
             }
 
             return newResponse;
         } catch (err) {
             console.error('Hat-server: Website API call catch error:', err);
             if (global['monitoringProvider'] && global['monitoringProvider'].counter) {
-                global['monitoringProvider'].counter('info.HatServer_callToWebsitesApi.apiCallCatchError');
+                global['monitoringProvider'].counter('error.HatServer_callToWebsitesApi.apiCallCatchError');
             }
             return null;
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ import { ApolloQueryResult } from "@apollo/client";
 import http from "http";
 import {DocumentNode} from "graphql/language/ast";
 import {UrlWithParsedQuery} from "url";
-import {Site} from "@ringpublishing/graphql-api-client/lib/types/websites-api";
+import {Site} from "@ringpublishing/graphql-api-client-got/lib/types/websites-api";
 
 export interface BootServerConfig {
     /**


### PR DESCRIPTION
Changed monitoring counter labels from 'info' to 'error' for API call errors and catch errors. Added a new counter for cases where the API response contains no data, enhancing observability of error scenarios.